### PR TITLE
Add bitwarden

### DIFF
--- a/roles/system/fedora-rpm-ostree/tasks/main.yml
+++ b/roles/system/fedora-rpm-ostree/tasks/main.yml
@@ -6,7 +6,7 @@
 - include_vars: fedora_packages.yml
 
 - name: add RPM Fusion repos
-  shell: "sudo rpm-ostree install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-{{ fedora_version }}.noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-{{ fedora_version }}.noarch.rpm"
+  shell: "rpm-ostree install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-{{ fedora_version }}.noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-{{ fedora_version }}.noarch.rpm || true"
   become: true
   tags:
     - rpmfusion

--- a/roles/system/fedora-silverblue/vars/flathub_apps.yml
+++ b/roles/system/fedora-silverblue/vars/flathub_apps.yml
@@ -2,6 +2,7 @@
 flathub_install_list:
     # System
     - com.uploadedlobster.peek
+    - com.bitwarden
     # Communication
     - org.quassel_irc.QuasselClient
     - com.slack.Slack


### PR DESCRIPTION
- Added bitwarden to the flatpak installs
- Temp fixed the `rpm-ostree update` command to return as `true` even on failure, so the playbook will still run even if there are no updates.